### PR TITLE
Add support for providing document symbols

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.8', '3.9']
     name: run tests for python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Salt Language Server Protocol Server
 
 ## Prerequisites
 
-- Python >= 3.7
+- Python >= 3.8
 - VSCode (required for live testing the server from an editor)
 
 

--- a/salt_lsp/document_symbols.py
+++ b/salt_lsp/document_symbols.py
@@ -1,0 +1,215 @@
+"""
+Implementation of the DocumentSymbolsRequest, see:
+https://microsoft.github.io/language-server-protocol/specification#textDocument_documentSymbol
+"""
+from dataclasses import dataclass, field
+import itertools
+from typing import Callable, Dict, List, Sequence, TypedDict, cast
+
+from pygls.lsp import types
+
+from salt_lsp.parser import (
+    AstNode,
+    Tree,
+    Optional,
+    IncludeNode,
+    IncludesNode,
+    StateParameterNode,
+    StateCallNode,
+    StateNode,
+    RequisiteNode,
+    RequisitesNode,
+    ExtendNode,
+)
+from salt_lsp.base_types import CompletionsDict
+from salt_lsp.utils import ast_node_to_range
+
+
+class DocumentSymbolKWArgs(TypedDict):
+    """
+    Keyword arguments for the DocumentSymbol constructor that can be extracted
+    for every AstNode.
+    """
+
+    name: str
+    range: types.Range
+    selection_range: types.Range
+    kind: types.SymbolKind
+
+
+#: Dictionary containing functions that convert the AstNode subclasses to their
+#: string identifier
+NODE_IDENTIFIERS: Dict[str, Callable[[AstNode], Optional[str]]] = {
+    IncludeNode.__name__: lambda node: cast(IncludeNode, node).value,
+    IncludesNode.__name__: lambda node: "includes",
+    StateParameterNode.__name__: lambda node: cast(
+        StateParameterNode, node
+    ).name,
+    StateCallNode.__name__: lambda node: cast(StateCallNode, node).name,
+    StateNode.__name__: lambda node: cast(StateNode, node).identifier,
+    RequisiteNode.__name__: lambda node: cast(RequisiteNode, node).module,
+    RequisitesNode.__name__: lambda node: cast(RequisitesNode, node).kind,
+    ExtendNode.__name__: lambda node: "extend",
+}
+
+
+def _get_doc_from_module_name(
+    node: AstNode,
+    state_completions: CompletionsDict,
+) -> Optional[str]:
+    """
+    This function returns the documentation of a StateCallNode or a
+    RequisiteNode from its name using the state_completions dictionary.
+
+    This function must not be used for other types of AstNode subclasses.
+    """
+    assert isinstance(node, (RequisiteNode, StateCallNode))
+
+    mod_name = NODE_IDENTIFIERS[type(node).__name__](node)
+    if mod_name is None:
+        return None
+
+    if "." in mod_name:
+        mod_base_name, submod_name = mod_name.split(".")
+        completer = state_completions.get(mod_base_name)
+        if completer is None:
+            return None
+        submod_params = completer.state_params.get(submod_name)
+        return (
+            submod_params.documentation if submod_params is not None else None
+        )
+
+    completer = state_completions.get(mod_name)
+    return completer.state_docs if completer is not None else None
+
+
+#: Dictionary of functions that return the documentation of a AstNode given the
+#: AstNode and the CompletionsDict
+DETAIL_OF_NODE_CONSTRUCTOR: Dict[
+    str, Callable[[AstNode, CompletionsDict], Optional[str]]
+] = {
+    RequisiteNode.__name__: _get_doc_from_module_name,
+    StateCallNode.__name__: _get_doc_from_module_name,
+    ExtendNode.__name__: lambda n, c: """Extension of external SLS data.
+See: https://docs.saltproject.io/en/latest/ref/states/extend.html
+""",
+    IncludesNode.__name__: lambda n, c: """A list of included SLS files.
+See also https://docs.saltproject.io/en/latest/ref/states/include.html
+""",
+    RequisitesNode.__name__: lambda n, c: """List of requisites.
+See also: https://docs.saltproject.io/en/latest/ref/states/requisites.html
+""",
+}
+
+
+def get_children(
+    node: AstNode, state_completions: CompletionsDict
+) -> List[types.DocumentSymbol]:
+    children: Sequence[AstNode] = []
+    if isinstance(node, IncludesNode):
+        children = node.includes
+    elif isinstance(
+        node, (ExtendNode, RequisitesNode, StateCallNode, StateNode)
+    ):
+        children = node.get_children()
+    else:
+        return []
+
+    visitor = Visitor(state_completions=state_completions, recurse=False)
+    for child in children:
+        child.visit(visitor)
+
+    assert isinstance(visitor.document_symbols, list)
+    return visitor.document_symbols
+
+
+def _document_symbol_init_kwargs(
+    node: AstNode,
+) -> Optional[DocumentSymbolKWArgs]:
+    string_identifier = NODE_IDENTIFIERS.get(
+        type(node).__name__, lambda node: None
+    )(node)
+    symbol_kind = (
+        types.SymbolKind.String
+        if isinstance(node, IncludeNode)
+        else types.SymbolKind.Object
+    )
+
+    if string_identifier is None or node.start is None or node.end is None:
+        return None
+
+    lsp_range = ast_node_to_range(node)
+    assert lsp_range is not None
+
+    return {
+        "name": string_identifier,
+        "range": lsp_range,
+        "selection_range": types.Range(
+            start=node.start.to_lsp_pos(),
+            end=types.Position(
+                line=node.start.line,
+                character=node.start.col + len(string_identifier),
+            ),
+        ),
+        "kind": symbol_kind,
+    }
+
+
+@dataclass
+class Visitor:
+    """
+    Stateful visitor that constructs the document symbols from a AstNode
+    utilizing the visit() function.
+    """
+
+    #: The resulting document symbols created from the AstNode are saved in
+    #: this field
+    document_symbols: List[types.DocumentSymbol] = field(default_factory=list)
+
+    #: The visitor uses this attribute to obtain the documentation of certain
+    #: AstNodes.
+    state_completions: CompletionsDict = field(default_factory=dict)
+
+    #: This attribute specifies whether the visitor will be called on the
+    #: children of the AstNode.
+    #: By default this is not the case and should not be enabled, as LSP
+    #: clients will not be able to use the resulting document symbols list.
+    recurse: bool = False
+
+    def __call__(self, node: AstNode) -> bool:
+        kwargs = _document_symbol_init_kwargs(node)
+        if kwargs is None:
+            return self.recurse
+
+        self.document_symbols.append(
+            types.DocumentSymbol(
+                detail=DETAIL_OF_NODE_CONSTRUCTOR.get(
+                    type(node).__name__, lambda n, c: None
+                )(node, self.state_completions)
+                or "",
+                children=get_children(node, self.state_completions),
+                **kwargs,
+            )
+        )
+        return self.recurse
+
+
+def tree_to_document_symbols(
+    tree: Tree, state_completions: CompletionsDict
+) -> List[types.DocumentSymbol]:
+
+    res = []
+
+    for elem in itertools.chain.from_iterable(
+        (
+            ([tree.includes] if tree.includes else []),
+            ([tree.extend] if tree.extend else []),
+            tree.states,
+        )
+    ):
+        visitor = Visitor(state_completions=state_completions, recurse=False)
+        elem.visit(visitor)
+
+        res += visitor.document_symbols
+
+    return res

--- a/salt_lsp/parser.py
+++ b/salt_lsp/parser.py
@@ -7,33 +7,14 @@ import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from os.path import abspath, dirname, exists, join
-from typing import (
-    Any,
-    Callable,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    TypedDict,
-    Union,
-    cast,
-)
+from typing import Any, Callable, List, Optional, Sequence, Tuple, Union, cast
 
 from pygls.lsp import types
 import yaml
 from yaml.tokens import BlockEndToken, ScalarToken
 
-from salt_lsp.base_types import CompletionsDict
-
 
 log = logging.getLogger(__name__)
-
-
-class DocumentSymbolKWArgs(TypedDict):
-    name: str
-    range: types.Range
-    selection_range: types.Range
-    kind: types.SymbolKind
 
 
 @dataclass
@@ -90,45 +71,6 @@ class AstNode(ABC):
         """
         visitor(self)
 
-    @abstractmethod
-    def to_document_symbol(
-        self, state_completions: CompletionsDict
-    ) -> Optional[types.DocumentSymbol]:
-        """
-        Converts this node into a DocumentSymbol unless some crucial
-        information are missing.
-        """
-        raise NotImplementedError()
-
-    def to_range(self) -> Optional[types.Range]:
-        if self.start is None or self.end is None:
-            return None
-        return types.Range(
-            start=self.start.to_lsp_pos(), end=self.end.to_lsp_pos()
-        )
-
-    def _document_symbol_init_kwargs(
-        self,
-        string_identifier: Optional[str],
-        symbol_kind: types.SymbolKind = types.SymbolKind.Object,
-    ) -> Optional[DocumentSymbolKWArgs]:
-        if string_identifier is None or self.start is None or self.end is None:
-            return None
-        lsp_range = self.to_range()
-        assert lsp_range is not None
-        return {
-            "name": string_identifier,
-            "range": lsp_range,
-            "selection_range": types.Range(
-                start=self.start.to_lsp_pos(),
-                end=types.Position(
-                    line=self.start.line,
-                    character=self.start.col + len(string_identifier),
-                ),
-            ),
-            "kind": symbol_kind,
-        }
-
 
 class AstMapNode(AstNode, ABC):
     """
@@ -166,14 +108,6 @@ class IncludeNode(AstNode):
 
     value: Optional[str] = None
 
-    def to_document_symbol(
-        self, state_completions: CompletionsDict
-    ) -> Optional[types.DocumentSymbol]:
-        kwargs = self._document_symbol_init_kwargs(
-            self.value, types.SymbolKind.String
-        )
-        return None if kwargs is None else types.DocumentSymbol(**kwargs)
-
     def get_file(self: IncludeNode, top_path: str) -> Optional[str]:
         """
         Convert the dotted value of the include into a proper file path
@@ -209,24 +143,6 @@ class IncludesNode(AstNode):
         """
         self.includes.append(IncludeNode())
         return self.includes[-1]
-
-    def to_document_symbol(
-        self, state_completions: CompletionsDict
-    ) -> Optional[types.DocumentSymbol]:
-        kwargs = self._document_symbol_init_kwargs("includes")
-
-        return (
-            None
-            if kwargs is None
-            else types.DocumentSymbol(
-                children=list(
-                    child.to_document_symbol for child in self.includes
-                ),
-                detail="""A list of included SLS files.
-See also https://docs.saltproject.io/en/latest/ref/states/include.html""",
-                **kwargs,
-            )
-        )
 
 
 @dataclass
@@ -266,12 +182,6 @@ class StateParameterNode(AstNode):
         self.name = key
         return self
 
-    def to_document_symbol(
-        self, state_completions: CompletionsDict
-    ) -> Optional[types.DocumentSymbol]:
-        kwargs = self._document_symbol_init_kwargs(self.name)
-        return None if kwargs is None else types.DocumentSymbol(**kwargs)
-
 
 @dataclass
 class RequisiteNode(AstNode):
@@ -291,17 +201,6 @@ class RequisiteNode(AstNode):
         """
         self.module = key
         return self
-
-    def to_document_symbol(
-        self, state_completions: CompletionsDict
-    ) -> Optional[types.DocumentSymbol]:
-        kwargs = self._document_symbol_init_kwargs(self.module)
-        if kwargs is None:
-            return None
-        detail = None
-        if self.module in state_completions:
-            detail = state_completions[self.module].state_docs
-        return types.DocumentSymbol(detail=detail, **kwargs)
 
 
 @dataclass
@@ -337,25 +236,6 @@ class RequisitesNode(AstMapNode):
         Returns all the children nodes
         """
         return self.requisites
-
-    def to_document_symbol(
-        self, state_completions: CompletionsDict
-    ) -> Optional[types.DocumentSymbol]:
-        kwargs = self._document_symbol_init_kwargs(self.kind)
-        return (
-            None
-            if kwargs is None
-            else types.DocumentSymbol(
-                detail="""List of requisites.
-See also: https://docs.saltproject.io/en/latest/ref/states/requisites.html
-""",
-                children=list(
-                    req.to_document_symbol(state_completions)
-                    for req in self.requisites
-                ),
-                **kwargs,
-            )
-        )
 
 
 @dataclass
@@ -419,26 +299,6 @@ class StateCallNode(AstMapNode):
             List[AstNode], self.requisites
         )
 
-    def to_document_symbol(
-        self, state_completions: CompletionsDict
-    ) -> Optional[types.DocumentSymbol]:
-        kwargs = self._document_symbol_init_kwargs(self.name)
-        detail = None
-        if self.name in state_completions:
-            detail = state_completions[self.name].state_docs
-        return (
-            None
-            if kwargs is None
-            else types.DocumentSymbol(
-                children=list(
-                    state.to_document_symbol(state_completions)
-                    for state in self.parameters + self.requisites
-                ),
-                detail=detail,
-                **kwargs,
-            )
-        )
-
 
 @dataclass
 class StateNode(AstMapNode):
@@ -483,22 +343,6 @@ class StateNode(AstMapNode):
         """
         return self.states
 
-    def to_document_symbol(
-        self, state_completions: CompletionsDict
-    ) -> Optional[types.DocumentSymbol]:
-        kwargs = self._document_symbol_init_kwargs(self.identifier)
-        return (
-            None
-            if kwargs is None
-            else types.DocumentSymbol(
-                children=list(
-                    state.to_document_symbol(state_completions)
-                    for state in self.states
-                ),
-                **kwargs,
-            )
-        )
-
 
 @dataclass
 class ExtendNode(AstMapNode):
@@ -522,25 +366,6 @@ class ExtendNode(AstMapNode):
         Returns all the children nodes
         """
         return self.states
-
-    def to_document_symbol(
-        self, state_completions: CompletionsDict
-    ) -> Optional[types.DocumentSymbol]:
-        kwargs = self._document_symbol_init_kwargs("extend")
-        return (
-            None
-            if kwargs is None
-            else types.DocumentSymbol(
-                children=list(
-                    state.to_document_symbol(state_completions)
-                    for state in self.states
-                ),
-                detail="""Extension of external SLS data.
-See: https://docs.saltproject.io/en/latest/ref/states/extend.html
-""",
-                **kwargs,
-            )
-        )
 
 
 @dataclass
@@ -597,11 +422,6 @@ class Tree(AstMapNode):
             + cast(List[AstNode], self.states)
         )
 
-    def to_document_symbol(
-        self, state_completions: CompletionsDict
-    ) -> Optional[types.DocumentSymbol]:
-        return None
-
 
 @dataclass(init=False, eq=False)
 class TokenNode(AstNode):
@@ -629,11 +449,6 @@ class TokenNode(AstNode):
         is_scalar = isinstance(self.token, yaml.ScalarToken)
         scalar_equal = is_scalar and self.token.value == other.token.value
         return super().__eq__(other) and (scalar_equal or not is_scalar)
-
-    def to_document_symbol(
-        self, state_completions: CompletionsDict
-    ) -> Optional[types.DocumentSymbol]:
-        raise NotImplementedError()
 
 
 class Parser:

--- a/salt_lsp/server.py
+++ b/salt_lsp/server.py
@@ -28,6 +28,7 @@ from ruamel import yaml
 
 import salt_lsp.utils as utils
 from salt_lsp.base_types import StateNameCompletion
+from salt_lsp.document_symbols import tree_to_document_symbols
 from salt_lsp.parser import (
     IncludesNode,
     RequisiteNode,
@@ -379,21 +380,7 @@ def document_symbol(
         return None
 
     tree = parse(sls_file.contents)
-    document_symbols: List[types.DocumentSymbol] = []
-
-    if tree.includes is not None:
-        document_symbols.append(
-            tree.includes.to_document_symbol(salt_srv._state_name_completions)
-        )
-
-    if tree.extend is not None:
-        document_symbols.append(
-            tree.extend.to_document_symbol(salt_srv._state_name_completions)
-        )
-
-    for state in tree.states:
-        document_symbols.append(
-            state.to_document_symbol(salt_srv._state_name_completions)
-        )
-
-    return document_symbols
+    doc_symbols = tree_to_document_symbols(
+        tree, salt_srv._state_name_completions
+    )
+    return doc_symbols

--- a/salt_lsp/utils.py
+++ b/salt_lsp/utils.py
@@ -9,9 +9,10 @@ import subprocess
 from typing import Iterator, List, Optional, TypeVar
 from urllib.parse import urlparse
 
-from pygls.lsp.types import Position
+from pygls.lsp.types import Position, Range
 
 import salt_lsp.parser as parser
+from salt_lsp.parser import AstNode
 
 
 def get_git_root(path: str) -> str:
@@ -120,3 +121,14 @@ def is_valid_file_uri(uri: str) -> bool:
         return True
     except ValueError:
         return False
+
+
+def ast_node_to_range(node: AstNode) -> Optional[Range]:
+    """
+    Converts a AstNode to a Range spanning from the node's starts to its end.
+
+    If the node's start or end are None, then None is returned.
+    """
+    if node.start is None or node.end is None:
+        return None
+    return Range(start=node.start.to_lsp_pos(), end=node.end.to_lsp_pos())


### PR DESCRIPTION
This is a bit crude implementation of the document symbol capability leveraging the new AST.

Current drawbacks:
- everything is stuffed into the AST classes (I think this is reasonable, but it could become a mess if we add all the capabalities into the node classes)
- The selection range (range identifying the "main" symbol) is atm computed from the start of the node to `start + len(identifier)`. This should be good enough, but maybe we should extract this information from the yaml parser?