### PR TITLE
Add version to SLS files

### DIFF
--- a/salt_lsp/server.py
+++ b/salt_lsp/server.py
@@ -43,7 +43,9 @@ class SlsFile:
     path: str
     parsed_contents: Optional[Any] = None
     parsed_contents_stale: bool = True
-    includes: List[str] = field(default_factory=list)
+
+    #: A list of URIs with the includes of this sls file
+    includes: List[utils.Uri] = field(default_factory=list)
 
     @staticmethod
     def resolve_include(top_sls_dir: str, include_entry: str) -> Optional[str]:
@@ -70,7 +72,7 @@ class SlsFile:
                 and top_sls_location is not None
             ):
                 self.includes = list(
-                    f"file://{path}"
+                    utils.Uri(f"file://{path}")
                     for path in filter(
                         None,
                         (

--- a/salt_lsp/utils.py
+++ b/salt_lsp/utils.py
@@ -6,7 +6,7 @@ import os
 import os.path
 import shlex
 import subprocess
-from typing import Iterator, List, Optional, TypeVar
+from typing import Iterator, List, NewType, Optional, TypeVar, Union
 from urllib.parse import urlparse
 
 from pygls.lsp.types import Position, Range
@@ -101,10 +101,14 @@ def get_last_element_of_iterator(iterator: Iterator[T]) -> Optional[T]:
         return None
 
 
+#: Type for URIs
+Uri = NewType("Uri", str)
+
+
 class FileUri:
     """Simple class for handling file:// URIs"""
 
-    def __init__(self, uri: str) -> None:
+    def __init__(self, uri: Union[str, Uri]) -> None:
         self._parse_res = urlparse(uri)
         if self._parse_res.scheme != "" and self._parse_res.scheme != "file":
             raise ValueError(f"Invalid uri scheme {self._parse_res.scheme}")

--- a/tests/test_completions.py
+++ b/tests/test_completions.py
@@ -467,7 +467,9 @@ salt_server.post_init(FILE_NAME_COMPLETER)
 class TestStateNameCompletion:
     def test_complete_of_file(self):
         txt_doc = {
-            "text_document": SimpleNamespace(uri="foo.sls", text=TEST_FILE)
+            "text_document": SimpleNamespace(
+                uri="foo.sls", text=TEST_FILE, version=0
+            ),
         }
         salt_server.register_file(SimpleNamespace(**txt_doc))
 


### PR DESCRIPTION
LSP includes a version of text documents which we were not tracking so far. I have seen that vscode complains about the version field missing in the reply to the `textDocumentDidOpen` notification, so I have added it here as well.