### PR TITLE
Handle plain top level dictionaries

### DIFF
--- a/salt_lsp/parser.py
+++ b/salt_lsp/parser.py
@@ -67,7 +67,8 @@ class AstNode(ABC):
 
     def visit(self: AstNode, visitor: Callable[[AstNode], bool]) -> None:
         """
-        Apply a visitor function to the node and apply it on children if the function returns True.
+        Apply a visitor function to the node and apply it on children if the
+        function returns True.
         """
         visitor(self)
 
@@ -93,7 +94,8 @@ class AstMapNode(AstNode, ABC):
 
     def visit(self, visitor: Callable[[AstNode], bool]) -> None:
         """
-        Apply a visitor function to the node and apply it on children if the function returns True.
+        Apply a visitor function to the node and apply it on children if the
+        function returns True.
         """
         if visitor(self):
             for child in self.get_children():
@@ -156,8 +158,8 @@ class StateParameterNode(AstNode):
 
     def set_key(self: StateParameterNode, key: str) -> AstNode:
         """
-        Set the name of the parameter. If getting a requisites, tell the parent to handle it
-        and return the newly created node.
+        Set the name of the parameter. If getting a requisites, tell the parent
+        to handle it and return the newly created node.
 
         :return: the node that finally got the name
         """
@@ -327,8 +329,8 @@ class StateNode(AstMapNode):
 
     def set_key(self: StateNode, key: str) -> AstNode:
         """
-        Set the identifier of the node. If the ikey is one of include or extend,
-        tell the parent to handle it.
+        Set the identifier of the node. If the ikey is one of include or
+        extend, tell the parent to handle it.
 
         :return: the node where the key has been set.
         """
@@ -389,12 +391,14 @@ class Tree(AstMapNode):
 
     def convert(self: Tree, state: StateNode, name: str) -> AstNode:
         """
-        Convert a child state node into the proper node type depending on the name.
+        Convert a child state node into the proper node type depending on the
+        name.
 
         :param state: the state node to change
         :param name: the name of the state node
 
-        :return: the state node if no change was needed or the newly created node
+        :return: the state node if no change was needed or the newly created
+            node
         """
         self.states.remove(state)
 
@@ -617,9 +621,9 @@ class Parser:
                 changed = getattr(self._breadcrumbs[-1], "set_key")(
                     token.value
                 )
-                # If the changed node isn't the same than the one we called the function on,
-                # that means that the node had to be converted and we need to
-                # update the breadcrumbs too.
+                # If the changed node isn't the same than the one we called the
+                # function on, that means that the node had to be converted and
+                # we need to update the breadcrumbs too.
                 if changed != self._breadcrumbs[-1]:
                     old = self._breadcrumbs.pop()
                     self._breadcrumbs.append(changed)
@@ -652,7 +656,8 @@ class Parser:
 
     def parse(self) -> Tree:
         """
-        Generate the Abstract Syntax Tree for a ``jinja|yaml`` rendered SLS file.
+        Generate the Abstract Syntax Tree for a ``jinja|yaml`` rendered SLS
+        file.
 
         :return: the generated AST
         :raises ValueException: for any other renderer but ``jinja|yaml``

--- a/salt_lsp/parser.py
+++ b/salt_lsp/parser.py
@@ -663,10 +663,8 @@ class Parser:
         try:
             for token in tokens:
                 log.debug(token)
-                print(token)
                 self._process_token(token)
         except yaml.scanner.ScannerError as err:
-            print(err)
             log.debug(err)
             if token:
                 # Properly close the opened blocks

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -621,7 +621,7 @@ def test_state_no_param():
         states=[
             StateNode(
                 start=Position(line=0, col=0),
-                end=Position(line=2, col=0),
+                end=Position(line=1, col=14),
                 identifier="jdoe",
                 states=[
                     StateCallNode(

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -793,3 +793,65 @@ def test_pop_breadcrumb_from_flow_sequence():
             )
         ],
     )
+
+
+def test_list_index_out_of_range():
+    contents = """
+root:
+  user.present
+
+ilmehtar:
+  user.present:
+    - fullname: Richard Brown
+    - home: /home/ilmehtar
+"""
+    tree = parse(contents)
+    assert tree == Tree(
+        start=Position(line=0, col=0),
+        end=Position(line=8, col=0),
+        includes=None,
+        extend=None,
+        states=[
+            StateNode(
+                start=Position(line=1, col=0),
+                end=Position(line=2, col=14),
+                identifier="root",
+                states=[
+                    StateCallNode(
+                        start=Position(line=2, col=2),
+                        end=Position(line=2, col=14),
+                        name="user.present",
+                        parameters=[],
+                        requisites=[],
+                    )
+                ],
+            ),
+            StateNode(
+                start=Position(line=4, col=0),
+                end=Position(line=8, col=0),
+                identifier="ilmehtar",
+                states=[
+                    StateCallNode(
+                        start=Position(line=5, col=2),
+                        end=Position(line=8, col=0),
+                        name="user.present",
+                        parameters=[
+                            StateParameterNode(
+                                start=Position(line=6, col=4),
+                                end=Position(line=7, col=4),
+                                name="fullname",
+                                value="Richard Brown",
+                            ),
+                            StateParameterNode(
+                                start=Position(line=7, col=4),
+                                end=Position(line=8, col=0),
+                                name="home",
+                                value="/home/ilmehtar",
+                            ),
+                        ],
+                        requisites=[],
+                    )
+                ],
+            ),
+        ],
+    )


### PR DESCRIPTION
Add flag to _process_token tracking whether the next token is a value

This allows us to correctly parse the following yaml:
```yaml
root:
  user.present

anything else:
```
Here the issue was, that while the `user.present` is correctly added, the
StateNode('root') is not terminated after the `user.present` because there are
no `Block*Start*Token` preceding it. The flag `self._next_token_is_value` is now
used to distinguish these cases and if such a plain dictionary appears, then we
remove the processed node from the breadcrumbs as it is now "finished"

This fixes #5 