### PR TITLE
Remove duplicated function calls in our handlers

### DIFF
--- a/salt_lsp/base_types.py
+++ b/salt_lsp/base_types.py
@@ -46,10 +46,10 @@ class StateNameCompletion:
 
         The documentation is not guaranteed to be present and can be None.
         """
-        return list(
-            (key, self.state_params[key].documentation)
-            for key in self.state_params
-        )
+        return [
+            (name, state_params.documentation)
+            for name, state_params in self.state_params.items()
+        ]
 
     def provide_param_completion(self, submod_name: str) -> List[str]:
         return list(self.state_params[submod_name].parameters.keys())

--- a/salt_lsp/server.py
+++ b/salt_lsp/server.py
@@ -10,8 +10,6 @@ from typing import Dict, List, Optional, Sequence, Tuple, Union, cast
 from pygls.capabilities import COMPLETION
 from pygls.lsp import types
 from pygls.lsp.methods import (
-    TEXT_DOCUMENT_DID_CHANGE,
-    TEXT_DOCUMENT_DID_CLOSE,
     TEXT_DOCUMENT_DID_OPEN,
     DEFINITION,
     DOCUMENT_SYMBOL,
@@ -218,25 +216,6 @@ def setup_salt_server_capabilities(server: SaltServer) -> None:
 
         return salt_server.find_id_in_doc_and_includes(id_to_find, uri)
 
-    @server.feature(TEXT_DOCUMENT_DID_CHANGE)
-    def on_did_change(
-        salt_server: SaltServer, params: types.DidChangeTextDocumentParams
-    ):
-        for change in params.content_changes:
-            # check that this is a types.TextDocumentContentChangeEvent
-            if hasattr(change, "range"):
-                assert isinstance(change, types.TextDocumentContentChangeEvent)
-                salt_server.workspace.update_document(
-                    params.text_document, change
-                )
-
-    @server.feature(TEXT_DOCUMENT_DID_CLOSE)
-    def did_close(
-        salt_server: SaltServer, params: types.DidCloseTextDocumentParams
-    ):
-        """Text document did close notification."""
-        salt_server.workspace.remove_document(params.text_document.uri)
-
     @server.feature(TEXT_DOCUMENT_DID_OPEN)
     def did_open(
         salt_server: SaltServer, params: types.DidOpenTextDocumentParams
@@ -249,7 +228,6 @@ def setup_salt_server_capabilities(server: SaltServer) -> None:
             "adding text document '%s' to the workspace",
             params.text_document.uri,
         )
-        salt_server.workspace.put_document(params.text_document)
         doc = salt_server.workspace.get_document(params.text_document.uri)
         return types.TextDocumentItem(
             uri=params.text_document.uri,

--- a/salt_lsp/server.py
+++ b/salt_lsp/server.py
@@ -22,7 +22,7 @@ from pygls.lsp.types import (
 )
 from pygls.server import LanguageServer
 
-import salt_lsp.utils as utils
+from salt_lsp import utils
 from salt_lsp.base_types import StateNameCompletion, SLS_LANGUAGE_ID
 from salt_lsp.workspace import SaltLspProto, SlsFileWorkspace
 from salt_lsp.parser import (
@@ -59,6 +59,8 @@ class SaltServer(LanguageServer):
         state_name_completions: Dict[str, StateNameCompletion],
         log_level=logging.DEBUG,
     ) -> None:
+        """Further initialisation, called after
+        setup_salt_server_capabilities."""
         self._state_name_completions = state_name_completions
         self._state_names = list(state_name_completions.keys())
         self.logger = logging.getLogger(self.__class__.__name__)
@@ -67,6 +69,7 @@ class SaltServer(LanguageServer):
     def complete_state_name(
         self, params: types.CompletionParams
     ) -> List[Tuple[str, Optional[str]]]:
+        """Complete state name at current position"""
         assert (
             params.context is not None
             and params.context.trigger_character == "."
@@ -242,6 +245,6 @@ def setup_salt_server_capabilities(server: SaltServer) -> None:
     ) -> Optional[
         Union[List[types.DocumentSymbol], List[types.SymbolInformation]]
     ]:
-        return salt_server.workspace._document_symbols.get(
+        return salt_server.workspace.document_symbols.get(
             params.text_document.uri, []
         )

--- a/salt_lsp/utils.py
+++ b/salt_lsp/utils.py
@@ -23,7 +23,7 @@ from urllib.parse import urlparse, ParseResult
 
 from pygls.lsp.types import Position, Range
 
-import salt_lsp.parser as parser
+from salt_lsp import parser
 from salt_lsp.parser import AstNode, Tree
 
 
@@ -83,7 +83,7 @@ def construct_path_to_position(tree: Tree, pos: Position) -> List[AstNode]:
     parser_pos = parser.Position(line=pos.line, col=pos.character)
 
     def visitor(node: AstNode) -> bool:
-        if parser_pos >= node.start and parser_pos < node.end:
+        if node.start <= parser_pos < node.end:
             nonlocal found_node
             found_node = node
         return True
@@ -133,7 +133,7 @@ class FileUri:
         self._parse_res: ParseResult = (
             uri._parse_res if isinstance(uri, FileUri) else urlparse(uri)
         )
-        if self._parse_res.scheme != "" and self._parse_res.scheme != "file":
+        if self._parse_res.scheme not in ("", "file"):
             raise ValueError(f"Invalid uri scheme {self._parse_res.scheme}")
         if self._parse_res.scheme == "":
             self._parse_res = urlparse("file://" + self._parse_res.path)
@@ -155,7 +155,7 @@ class UriDict(Generic[T], MutableMapping):
     """
 
     def __init__(self, *args, **kwargs):
-        self._data: Dict[str, T] = dict()
+        self._data: Dict[str, T] = {}
         self.update(dict(*args, **kwargs))
 
     def __getitem__(self, key: U) -> T:


### PR DESCRIPTION
pygls.protocol calls "base functions" before our own handlers. The functions that change the document must not be called twice to keep the server's document in sync with the client's document.

The [decorator](https://github.com/openlawlibrary/pygls/blob/bbf671f509b0d499a006daeeae8cdb78e3419fe5/pygls/protocol.py#L67) first calls [bf_text_document__did_change](https://github.com/openlawlibrary/pygls/blob/f248002a2fb8a10fb9a5d2bd5a0160a04a6189aa/pygls/protocol.py#L630) and friends, before it calls our handlers, registered with the `@server.feature` decorator.

Between the version we use and the latest tag, these functions were renamed from`bf_*` to `lsp_*`, but, afaik, the logic stays the same.