### PR TITLE
Log to stderr by default instead of salt-server.log

### DIFF
--- a/salt_lsp/__main__.py
+++ b/salt_lsp/__main__.py
@@ -44,6 +44,10 @@ def add_arguments(parser):
         "(useful for debugging/testing purposes)",
     )
     parser.add_argument(
+        "--log-file",
+        help="Redirect logs to the given file instead of writing to stderr",
+    )
+    parser.add_argument(
         "--log-level",
         choices=list(LOG_LEVEL_DICT.keys())
         + list(map(lambda level: level.upper(), LOG_LEVEL_DICT.keys())),
@@ -60,7 +64,7 @@ def main():
 
     log_level = loglevel_from_str(args.log_level[0])
     logging.basicConfig(
-        filename="salt-server.log",
+        filename=args.log_file,
         level=log_level,
         filemode="w",
     )
@@ -72,7 +76,7 @@ def main():
 
     salt_server = SaltServer()
     setup_salt_server_capabilities(salt_server)
-    salt_server.post_init(states, log_level)
+    salt_server.post_init(states)
 
     if args.stop_after_init:
         return

--- a/salt_lsp/__main__.py
+++ b/salt_lsp/__main__.py
@@ -47,7 +47,7 @@ def add_arguments(parser):
         "--log-level",
         choices=list(LOG_LEVEL_DICT.keys())
         + list(map(lambda level: level.upper(), LOG_LEVEL_DICT.keys())),
-        default=["debug"],
+        default=["warning"],
         nargs=1,
         help="Logging verbosity",
     )

--- a/salt_lsp/server.py
+++ b/salt_lsp/server.py
@@ -59,14 +59,12 @@ class SaltServer(LanguageServer):
     def post_init(
         self,
         state_name_completions: Dict[str, StateNameCompletion],
-        log_level=logging.DEBUG,
     ) -> None:
         """Further initialisation, called after
         setup_salt_server_capabilities."""
         self._state_name_completions = state_name_completions
         self._state_names = list(state_name_completions.keys())
         self.logger = logging.getLogger(self.__class__.__name__)
-        self.logger.setLevel(log_level)
 
     def complete_state_name(
         self, params: types.CompletionParams

--- a/salt_lsp/workspace.py
+++ b/salt_lsp/workspace.py
@@ -2,7 +2,7 @@
 contents utilizing the existing Workspace implementation from pygls.
 
 """
-from logging import getLogger, Logger, DEBUG
+from logging import getLogger, Logger
 from pathlib import Path
 import sys
 from typing import List, Optional, Union
@@ -59,8 +59,6 @@ class SlsFileWorkspace(Workspace):
         self._state_name_completions = state_name_completions
 
         self.logger: Logger = getLogger(self.__class__.__name__)
-        # FIXME: make this configurable
-        self.logger.setLevel(DEBUG)
 
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
Output logs to stderr by default instead of salt-server.log, to stop the
server from creating log files in the current working directory.

Add a "--log-file" flag to support writing logs to a given file instead
of stderr.

Update SaltServer and SlsFileWorkspace so they use the "--log-level"
flag value.

Update the default value of the "--log-level" flag to "warning".

---------------------

Using this with neovim leaves `salt-server.log` files around.  This change stops that, but still allows the user to specify a log file with `--log-file`, if needed.  Tests pass with `pytest`.  This seems to be working fine in neovim, however I'm not sure if logging to stderr will cause any issues with emacs or vscode.